### PR TITLE
Refactor tests, change cardContainer return element

### DIFF
--- a/public/styles/styles.css
+++ b/public/styles/styles.css
@@ -21,7 +21,8 @@ body {
   color: #fff;
 }
 
-h1 {
+h1,
+h2 {
   margin: 0;
 }
 
@@ -79,5 +80,5 @@ li {
 }
 
 .card__title {
-  font-size: 2rem;
+  font-size: 1.4rem;
 }

--- a/src/components/renderCard/renderCard.ts
+++ b/src/components/renderCard/renderCard.ts
@@ -2,9 +2,9 @@ import type { CharacterTypes } from "../../characters/data";
 import { renderCardContainer } from "../renderCardContainer/renderCardContainer.js";
 
 export const renderCard = (character: CharacterTypes): HTMLElement => {
-  const card = document.createElement("article");
+  const card = document.createElement("li");
 
-  const cardItem = document.createElement("li");
+  const cardItem = document.createElement("article");
 
   cardItem.classList.add("card");
 

--- a/src/components/renderCardContainer/renderCardContainer.test.ts
+++ b/src/components/renderCardContainer/renderCardContainer.test.ts
@@ -2,7 +2,7 @@ import { gotCharacters } from "../../characters/data.js";
 import { renderCardContainer } from "./renderCardContainer.js";
 
 describe("Given the card container component", () => {
-  describe("When the given character is the first one of the gotCharacters array", () => {
+  describe("When the given characer is Joffrey Baratheon", () => {
     test("Then it should render the name Joffrey Baratheon", () => {
       const screen = document.createElement("div");
 
@@ -12,7 +12,7 @@ describe("Given the card container component", () => {
 
       screen.appendChild(cardInformation);
 
-      const card = screen.querySelector("span");
+      const card = screen.querySelector("h2");
 
       expect(card).not.toBeNull();
       expect(card?.textContent).toBe("Joffrey Baratheon");

--- a/src/components/renderCardContainer/renderCardContainer.ts
+++ b/src/components/renderCardContainer/renderCardContainer.ts
@@ -9,7 +9,7 @@ export const renderCardContainer = (character: CharacterTypes): HTMLElement => {
   const cardInformation = renderCardInformation(character);
 
   cardContainer.innerHTML = `
-    <span class="card__title">${character.name} ${character.surname ?? ""}</span>
+    <h2 class="card__title">${character.name} ${character.surname ?? ""}</h2>
     ${cardInformation.outerHTML}
   `;
 

--- a/src/components/renderCardsList/renderCardsList.test.ts
+++ b/src/components/renderCardsList/renderCardsList.test.ts
@@ -2,18 +2,16 @@ import { gotCharacters } from "../../characters/data.js";
 import { renderCardsList } from "./renderCardsList.js";
 
 describe("Given the cards list renderer component", () => {
-  describe("When an array of characters is given", () => {
+  describe("When 5 characters are given", () => {
     test("Then it should render as many cards as characters exists in the array", () => {
       const screen = document.createElement("div");
       const characters = gotCharacters;
+      const charactersLength = gotCharacters.length;
+
       const cardsList = renderCardsList(characters);
-      const charactersLength = 5;
-
       screen.appendChild(cardsList);
-
       const cards = screen.querySelectorAll(".card");
 
-      expect(cards).not.toBeNull();
       expect(cards.length).toBe(charactersLength);
     });
   });

--- a/src/components/renderHeader/renderHeader.test.ts
+++ b/src/components/renderHeader/renderHeader.test.ts
@@ -3,8 +3,9 @@ import { renderHeader } from "./renderHeader";
 describe("Given the header component", () => {
   describe("When rendered", () => {
     test("Then it should show 'Game of Thrones' inside a heading", () => {
-      const screen = document.createElement("div");
+      const expectedAppTitle = "Game of Thrones";
 
+      const screen = document.createElement("div");
       const header = renderHeader();
 
       screen.appendChild(header);
@@ -12,7 +13,7 @@ describe("Given the header component", () => {
       const appTitle = screen.querySelector("h1");
 
       expect(appTitle).not.toBeNull();
-      expect(appTitle?.textContent).toBe("Game of Thrones");
+      expect(appTitle?.textContent).toBe(expectedAppTitle);
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { renderApp } from "./components/app/renderApp.js";
 const root = document.querySelector(".root");
 
 if (!root) {
-  throw new Error("Ha habido un error con el elemento root");
+  throw new Error("El elemento root no existe");
 }
 
 const app = renderApp();


### PR DESCRIPTION
- Refactored tests modifying their description and extracting magic numbers and string to variables
- Modified cardContainer function, now returns a `h2` element